### PR TITLE
Fixes console spam on RCON command when SpySession is enabled

### DIFF
--- a/GrabBag/src/aliuly/common/SpySession.php
+++ b/GrabBag/src/aliuly/common/SpySession.php
@@ -152,7 +152,7 @@ class SpySession extends Session {
 	 * @priority MONITOR
 	 */
 	public function onRconCmd(RemoteServerCommandEvent $ev) {
-    $this->logEvent(self::RCON,$ev->getMessage());
+    $this->logEvent(self::RCON,$ev->getCommand());
 	}
 	/**
 	 * @priority MONITOR


### PR DESCRIPTION
because RemoteServerCommandEvent doesn't has function getMessage()
