### PR TITLE
Change LiveSigns task to JSON for working with PHP7

### DIFF
--- a/LiveSigns/src/aliuly/livesigns/FetchTask.php
+++ b/LiveSigns/src/aliuly/livesigns/FetchTask.php
@@ -14,6 +14,7 @@ use aliuly\livesigns\fetcher\Motd;
 class FetchTask extends AsyncTask {
 	public $started;
 	public $owner;
+	public $re;
 	protected $pkgs;
 	protected $cf;
 	public function __construct($plugin,$cfg,$pkgs) {
@@ -56,7 +57,8 @@ class FetchTask extends AsyncTask {
 	}
 
 	public function onRun() {
-		$this->setResult(null);
+		//$this->setResult(null);
+		$this->re = json_encode(null);
 		$restab = [];
 		foreach ($this->pkgs as $job) {
 			list($id,$dat) = $job;
@@ -67,7 +69,8 @@ class FetchTask extends AsyncTask {
 				$restab[$id] = [ "error" => $res ];
 			}
 		}
-		$this->setResult($restab);
+		//$this->setResult($restab);
+		$this->re = json_encode($restab);
 	}
 	public function onCompletion(Server $server) {
 		$plugin = $server->getPluginManager()->getPlugin($this->owner);
@@ -77,7 +80,14 @@ class FetchTask extends AsyncTask {
 			return;
 		}
 		if (!$plugin->isEnabled()) return;
-		$res = $this->getResult();
+		//$res = $this->getResult();
+		if(!is_string($this->re)) {
+			$plugin->getLogger()->error("Error retrieving task results - no array in re");
+			return;
+			}
+
+
+		$res = json_decode($this->re, true);
 		if ($res == null) {
 			$plugin->getLogger()->error("Error retrieving task results");
 			return;

--- a/LiveSigns/src/aliuly/livesigns/LsCmds.php
+++ b/LiveSigns/src/aliuly/livesigns/LsCmds.php
@@ -136,7 +136,16 @@ class LsCmds extends BasicCli {
 			++$count;
 			$txt[] = TextFormat::AQUA.mc::_("LiveSign: ").TextFormat::WHITE.$id;
 			foreach ($stx[$id]["text"] as $k) {
-				$txt[] = TextFormat::AQUA."-   -".TextFormat::WHITE.$k;
+				if(is_array($k)) {
+					$i = 0;
+					foreach ($k as $k_line) {
+						$txt[] = TextFormat::AQUA."-   -".TextFormat::WHITE.$k[$i];
+						$i++;
+					}
+				unset($i,$k_line);
+				} else {
+					$txt[] = TextFormat::AQUA."-   -".TextFormat::WHITE.$k;
+				}
 			}
 			if (isset($stx[$id]["datetime"])) {
 				$txt[] = TextFormat::AQUA.mc::_("-    tstamp: ").

--- a/LiveSigns/src/aliuly/livesigns/Main.php
+++ b/LiveSigns/src/aliuly/livesigns/Main.php
@@ -227,7 +227,11 @@ class Main extends BasicPlugin implements CommandExecutor {
 			  $text = $this->signsTxt[$id]["text"];
 		}
 		if(isset($this->signsCfg[$id]["no-vars"])) return $text;
-		return explode("\n",strtr(implode("\n",$text),$this->vars));
+		//return explode("\n",strtr(implode("\n",$text),$this->vars));
+		if(is_array($text[0]))
+			return explode("\n",strtr(implode("\n",$text[0]),$this->vars));
+		else
+			return explode("\n",strtr(implode("\n",$text),$this->vars));
 	}
 	public function getLiveText($id,$opts) {
 		if (!isset($this->signsTxt[$id])) return null;

--- a/LiveSigns/src/aliuly/livesigns/TileUpdTask.php
+++ b/LiveSigns/src/aliuly/livesigns/TileUpdTask.php
@@ -4,7 +4,8 @@ namespace aliuly\livesigns;
 use pocketmine\scheduler\PluginTask;
 use pocketmine\plugin\Plugin;
 use pocketmine\tile\Sign;
-use pocketmine\network\protocol\TileEntityDataPacket;
+//use pocketmine\network\protocol\TileEntityDataPacket;
+use pocketmine\network\protocol\BlockEntityDataPacket;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\StringTag;
@@ -20,6 +21,7 @@ class TileUpdTask extends PluginTask{
 		$this->getOwner()->updateVars();
 		foreach ($this->getOwner()->getServer()->getLevels() as $lv) {
 			if (count($lv->getPlayers()) == 0) continue;
+			if ($lv === null) continue; // Skip all if level is not loaded
 			foreach ($lv->getTiles() as $tile) {
 				if (!($tile instanceof Sign)) continue;
 				$sign = $tile->getText();

--- a/LiveSigns/src/aliuly/livesigns/TileUpdTask.php
+++ b/LiveSigns/src/aliuly/livesigns/TileUpdTask.php
@@ -27,7 +27,7 @@ class TileUpdTask extends PluginTask{
 				$sign = $tile->getText();
 				$text = $this->getOwner()->getLiveSign($sign);
 				if ($text == null) continue;
-				$pk = new TileEntityDataPacket();
+				$pk = new BlockEntityDataPacket();
 				$data = $tile->getSpawnCompound();
 				$data->Text1 = new StringTag("Text1",$text[0]);
 				$data->Text2 = new StringTag("Text2",$text[1]);


### PR DESCRIPTION
I switched to JSON encode/decode of the array, because serialize/unserialize didn't work with php7 and now it workes for me.
